### PR TITLE
Fix: ue5.5 TPanelInChildren

### DIFF
--- a/Source/FairyGUI/Private/UI/UIPackage.cpp
+++ b/Source/FairyGUI/Private/UI/UIPackage.cpp
@@ -60,10 +60,10 @@ void UUIPackage::SetVar(const FString& VarKey, const FString& VarValue)
     UUIPackageStatic::Get().Vars.Add(VarKey, VarValue);
 }
 
-UUIPackage* UUIPackage::AddPackage(const TCHAR* InAssetPath, UObject* WorldContextObject)
+UUIPackage* UUIPackage::AddPackageByPath(const FString& InAssetPath, UObject* WorldContextObject)
 {
-    UUIPackageAsset* PackageAsset = Cast<UUIPackageAsset>(StaticLoadObject(UUIPackageAsset::StaticClass(), nullptr, InAssetPath));
-    verifyf(PackageAsset != nullptr, TEXT("Asset not found %s"), InAssetPath);
+    UUIPackageAsset* PackageAsset = Cast<UUIPackageAsset>(StaticLoadObject(UUIPackageAsset::StaticClass(), nullptr, *InAssetPath));
+    verifyf(PackageAsset != nullptr, TEXT("Asset not found %s"), *InAssetPath);
 
     return AddPackage(PackageAsset, WorldContextObject);
 }

--- a/Source/FairyGUI/Private/Widgets/SDisplayObject.cpp
+++ b/Source/FairyGUI/Private/Widgets/SDisplayObject.cpp
@@ -4,7 +4,7 @@
 #include "UI/GObject.h"
 
 bool SDisplayObject::bMindVisibleOnly = false;
-FNoChildren SDisplayObject::NoChildrenInstance;
+FNoChildren SDisplayObject::NoChildrenInstance = FNoChildren::NoChildrenInstance;
 FName SDisplayObject::SDisplayObjectTag("SDisplayObjectTag");
 
 SDisplayObject::SDisplayObject() :

--- a/Source/FairyGUI/Public/UI/UIPackage.h
+++ b/Source/FairyGUI/Public/UI/UIPackage.h
@@ -27,7 +27,8 @@ public:
     UFUNCTION(BlueprintCallable, Category = "FairyGUI", meta = (DisplayName = "Set UI Global Variable"))
     static void SetVar(const FString& VarKey, const FString& VarValue);
 
-    static UUIPackage* AddPackage(const TCHAR* InAssetPath, UObject* WorldContextObject);
+    UFUNCTION(BlueprintCallable, Category = "FairyGUI", meta = (WorldContext = "WorldContextObject"))
+    static UUIPackage* AddPackageByPath(const FString& InAssetPath, UObject* WorldContextObject);
 
     UFUNCTION(BlueprintCallable, Category = "FairyGUI", meta = (WorldContext = "WorldContextObject"))
     static UUIPackage* AddPackage(class UUIPackageAsset* InAsset, UObject* WorldContextObject);

--- a/Source/FairyGUI/Public/Widgets/SContainer.h
+++ b/Source/FairyGUI/Public/Widgets/SContainer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "SDisplayObject.h"
-#include "Utils/Children.h"
 
 class FAIRYGUI_API SContainer : public SDisplayObject
 {

--- a/Source/FairyGUI/Public/Widgets/SContainer.h
+++ b/Source/FairyGUI/Public/Widgets/SContainer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SDisplayObject.h"
+#include "Utils/Children.h"
 
 class FAIRYGUI_API SContainer : public SDisplayObject
 {
@@ -30,5 +31,5 @@ public:
     virtual FChildren* GetChildren() override;
 
 protected:
-    TPanelChildren<FSlotBase> Children;
+    TSlotlessChildren<SWidget> Children;
 };


### PR DESCRIPTION
fix #6 
使用`TSlotlessChildren<SWidget>`替换了`TPanelChildren<FSlotBase>`, 同时避免了`FSlotBase`单层嵌套`SWidget`的写法。 `TPanelChildren<>::Add(...)` 和`TPanelChildren<>::Insert(...)` 在源码中已经标记为deprecated.
替换后在ue5.5通过编译，可以显示